### PR TITLE
fix: removed content type header validation

### DIFF
--- a/src/Spryker/Glue/GlueApplication/Rest/Request/HeadersHttpRequestValidator.php
+++ b/src/Spryker/Glue/GlueApplication/Rest/Request/HeadersHttpRequestValidator.php
@@ -66,12 +66,6 @@ class HeadersHttpRequestValidator implements HeadersHttpRequestValidatorInterfac
                 ->setStatus(Response::HTTP_NOT_ACCEPTABLE);
         }
 
-        if (!isset($headerData[RequestConstantsInterface::HEADER_CONTENT_TYPE])) {
-            return (new RestErrorMessageTransfer())
-                ->setDetail('Unsupported media type.')
-                ->setStatus(Response::HTTP_UNSUPPORTED_MEDIA_TYPE);
-        }
-
         return null;
     }
 


### PR DESCRIPTION
## PR Description

This PR removes validation for the `Content-Type` header in the `Rest` layer. The rationale behind it is that [is valid HTTP to send a request without `Content-Type` header if the request does not have a body (GET or HEAD requests for instance)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type). Therefore, this validation should not run and instead make sure that in requests with a body the expected content type is found.

The reason why this is not currently broken is because Nginx sets `$_SERVER['CONTENT_TYPE']` to an empty string on `GET` requests that do not provide the `Content-Type` header explicitly, which is a legacy, undocumented and non-standard behavior that should not be relied upon. Headers in the CGI SAPI are only those `$_SERVER` keys prefixed by `HTTP_`. 

Unfortunately, the value of `$_SERVER['CONTENT_TYPE']` is considered and parsed by [`symfony/http-foundation`](https://github.com/symfony/http-foundation/blob/6.2/ServerBag.php#L32) for some reason. If you serve the Glue API with another proxy, like Caddy or Nginx Unit, `$_SERVER['CONTENT_TYPE']` would not be set and the `Content-Type` header will not be present, making this validator fail on perfectly valid GET requests.

The implications of keeping the rule in this validator is that effectively prevents using Spryker's Glue Api with any other CGI capable proxy that is not Nginx, and this is not good for Spryker's adoption and flexibility.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
